### PR TITLE
DRAFT: adding Spectral cones

### DIFF
--- a/cvxpy/constraints/logdet.py
+++ b/cvxpy/constraints/logdet.py
@@ -1,0 +1,69 @@
+"""
+Copyright 2025 CVXPY developers
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from cvxpy.constraints.cones import Cone
+from cvxpy.utilities import scopes
+
+
+# TODO: write docstrings for this
+class LogDet(Cone):
+    """
+    A constraint of the form :math:`\\log \\det(X) \\geq 0`
+    """
+
+    def __init__(self, expr, constr_id=None) -> None:
+        # Argument must be square matrix.
+        if len(expr.shape) != 2 or expr.shape[0] != expr.shape[1]:
+            raise ValueError(
+                "Non-square matrix in positive definite constraint."
+            )
+        super(LogDet, self).__init__([expr], constr_id)
+
+    def name(self) -> str:
+        return "LogDet(%s)" % self.args[0]
+
+    def is_dcp(self, dpp: bool = False) -> bool:
+        """A LogDet constraint is DCP if the constrained expression is affine.
+        """
+        if dpp:
+            with scopes.dpp_scope():
+                return self.args[0].is_affine()
+        return self.args[0].is_affine()
+
+    def is_dgp(self, dpp: bool = False) -> bool:
+        return False
+
+    def is_dqcp(self) -> bool:
+        return self.is_dcp()
+
+    # TODO implement these
+    @property
+    def residual(self):
+        """The residual of the constraint.
+
+        Returns
+        -------
+        NumPy.ndarray
+        """
+        raise NotImplementedError(
+            "LogDet residual is not implemented yet."
+        )
+
+    def _dual_cone(self, *args):
+        """Implements the dual cone of the LogDet cone"""
+        raise NotImplementedError(
+            "Dual cone of LogDet is not implemented yet."
+        )

--- a/cvxpy/reductions/dcp2cone/canonicalizers/log_det_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/log_det_canon.py
@@ -19,6 +19,7 @@ from cvxpy.atoms.affine.diag import diag_mat, diag_vec
 from cvxpy.atoms.affine.sum import sum
 from cvxpy.atoms.affine.upper_tri import vec_to_upper_tri
 from cvxpy.atoms.elementwise.log import log
+from cvxpy.constraints.logdet import LogDet
 from cvxpy.constraints.psd import PSD
 from cvxpy.expressions.variable import Variable
 from cvxpy.reductions.dcp2cone.canonicalizers.log_canon import log_canon
@@ -62,16 +63,4 @@ def log_det_canon(expr, args):
     tuple
         (Variable for objective, list of constraints)
     """
-    A = args[0]  # n by n matrix.
-    n, _ = A.shape
-    z = Variable(shape=(n*(n+1)//2,))
-    Z = vec_to_upper_tri(z, strict=False)
-    d = diag_mat(Z)  # a vector
-    D = diag_vec(d)  # a matrix
-    X = bmat([[D, Z],
-              [Z.T, A]])
-    constraints = [PSD(X)]
-    log_expr = log(d)
-    obj, constr = log_canon(log_expr, log_expr.args)
-    constraints += constr
-    return sum(obj), constraints
+    return LogDet(args[0])


### PR DESCRIPTION
## Description
Please include a short summary of the change.
TODO: 
- add tests for the exotic2common.
- make sure the logdet cone constraint is added to the SCS interface
- deal with when to call the exotic2common reduction vs. when to just pass the logdet cone
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.